### PR TITLE
Update lab logo

### DIFF
--- a/carpentrieslab-simple.svg
+++ b/carpentrieslab-simple.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="210mm"
+   viewBox="0 0 210 210"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)"
+   sodipodi:docname="carpentrieslab-simple.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.92517825"
+     inkscape:cx="394.4351"
+     inkscape:cy="454.45156"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g961"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1147"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:#071159;stroke:#36c3af;stroke-width:0"
+       id="path835"
+       cx="105"
+       cy="105"
+       r="40.82143" />
+    <ellipse
+       style="fill:none;stroke:#071159;stroke-width:7;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path837"
+       cx="105"
+       cy="105"
+       rx="49.938328"
+       ry="99.127045" />
+    <ellipse
+       style="fill:none;stroke:#071159;stroke-width:7;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path837-2"
+       cx="148.49243"
+       cy="1.8972258e-08"
+       rx="49.938328"
+       ry="99.127045"
+       transform="rotate(45)" />
+    <ellipse
+       style="fill:none;stroke:#071159;stroke-width:7;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path837-2-3"
+       cx="105"
+       cy="-105"
+       rx="49.938328"
+       ry="99.127045"
+       transform="rotate(90)" />
+    <ellipse
+       style="fill:none;stroke:#071159;stroke-width:7;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path837-2-3-7"
+       cx="-1.1731206e-06"
+       cy="-148.49243"
+       rx="49.938328"
+       ry="99.127045"
+       transform="rotate(135)" />
+    <circle
+       style="fill:#071159;stroke:#36c3af;stroke-width:0"
+       id="path835-0"
+       cx="48.47377"
+       cy="26.167253"
+       r="14.940157" />
+    <g
+       id="g961"
+       transform="matrix(0.26458333,0,0,0.26458333,79.548897,75.545111)">
+      <g
+         id="g967"
+         transform="matrix(2.785874,0,0,2.785874,-74.982096,-490.42336)">
+        <path
+           id="path2"
+           style="fill:#fafafb;fill-rule:evenodd"
+           d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z" />
+        <path
+           id="path4"
+           style="fill:#fafafb;fill-rule:evenodd"
+           d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z" />
+        <path
+           id="path6"
+           style="fill:#fafafb;fill-rule:evenodd"
+           d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z" />
+        <path
+           id="path8"
+           style="fill:#fafafb;fill-rule:evenodd"
+           d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/carpentrieslab.svg
+++ b/carpentrieslab.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -14,7 +12,7 @@
    viewBox="0 0 73.557359 73.55736"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)"
    sodipodi:docname="carpentrieslab.svg"
    inkscape:export-filename="/home/francois/Documents/dc-logos/carpentrieslab.png"
    inkscape:export-xdpi="261.26001"
@@ -28,21 +26,22 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.9475411"
-     inkscape:cx="98.273037"
-     inkscape:cy="111.51939"
+     inkscape:zoom="1.9322209"
+     inkscape:cx="141.8654"
+     inkscape:cy="140.58469"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="3840"
-     inkscape:window-height="2031"
+     inkscape:window-width="1252"
+     inkscape:window-height="943"
      inkscape:window-x="0"
-     inkscape:window-y="55"
-     inkscape:window-maximized="1"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
      fit-margin-top="2"
      fit-margin-left="2"
      fit-margin-right="2"
-     fit-margin-bottom="2" />
+     fit-margin-bottom="2"
+     inkscape:document-rotation="0" />
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -51,7 +50,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -61,189 +60,203 @@
      id="layer1"
      transform="translate(-54.318144,-58.060385)">
     <g
-       id="g1210"
-       transform="matrix(0.76511625,0,0,0.76511625,-1.4359246,-11.486705)">
-      <circle
-         r="13.396885"
-         cy="136.97237"
-         cx="120.93946"
-         id="path1058-5"
-         style="opacity:0.38299997;vector-effect:none;fill:#37abc8;fill-opacity:0.70689655;stroke:#37abc8;stroke-width:0.52916664;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       id="g18520">
       <g
-         transform="matrix(0.26458333,0,0,0.26458333,104.39672,79.101115)"
-         id="g852-0">
-        <path
-           inkscape:connector-curvature="0"
-           id="path2-3"
-           style="fill:#071159;fill-rule:evenodd"
-           d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path4-6"
-           style="fill:#071159;fill-rule:evenodd"
-           d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path6-1"
-           style="fill:#071159;fill-rule:evenodd"
-           d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path8-0"
-           style="fill:#071159;fill-rule:evenodd"
-           d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z" />
+         id="g1210"
+         transform="matrix(0.76511625,0,0,0.76511625,-1.4359238,-9.9607194)">
+        <circle
+           r="13.396885"
+           cy="136.97237"
+           cx="120.93946"
+           id="path1058-5"
+           style="opacity:0.383;vector-effect:none;fill:#e6f1ff;fill-opacity:1;stroke:#0044d7;stroke-width:1.30699;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
       </g>
-    </g>
-    <ellipse
-       style="opacity:0.94800002;vector-effect:none;fill:none;fill-opacity:1;stroke:#071159;stroke-width:0.53299999;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path1563"
-       cx="91.096825"
-       cy="94.839066"
-       rx="11.397929"
-       ry="34.51218" />
-    <ellipse
-       style="opacity:0.94800002;vector-effect:none;fill:none;fill-opacity:1;stroke:#071159;stroke-width:0.53299999;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path1563-9"
-       cx="93.31308"
-       cy="-91.096825"
-       rx="11.397929"
-       ry="34.51218"
-       transform="rotate(90)" />
-    <ellipse
-       style="opacity:0.94800002;vector-effect:none;fill:none;fill-opacity:1;stroke:#071159;stroke-width:0.53321892;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path1563-5"
-       cx="130.77599"
-       cy="1.9987698"
-       rx="11.397929"
-       ry="34.51218"
-       transform="rotate(45)" />
-    <ellipse
-       style="opacity:0.94800002;vector-effect:none;fill:none;fill-opacity:1;stroke:#071159;stroke-width:0.53299999;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path1563-5-0"
-       cx="1.5671302"
-       cy="130.39749"
-       rx="11.397929"
-       ry="34.51218"
-       transform="matrix(-0.70710678,0.70710678,0.70710678,0.70710678,0,0)" />
-    <circle
-       style="opacity:1;vector-effect:none;fill:#f4ddef;fill-opacity:1;stroke:#ff00cc;stroke-width:0.15319394;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path1058-32"
-       cx="69.472244"
-       cy="102.06955"
-       r="3.8784029" />
-    <g
-       id="g852-06"
-       transform="matrix(0.07659697,0,0,0.07659697,64.683117,85.315803)">
-      <path
-         d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path2-1"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path4-5"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path6-5"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path8-4"
-         inkscape:connector-curvature="0" />
-    </g>
-    <circle
-       style="opacity:1;vector-effect:none;fill:#fff3c4;fill-opacity:1;stroke:#ffcc00;stroke-width:0.15319394;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path1058-3-6"
-       cx="114.59357"
-       cy="80.660255"
-       r="3.8784029" />
-    <g
-       id="g852-1-5"
-       transform="matrix(0.07659697,0,0,0.07659697,109.80444,63.9065)">
-      <path
-         d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path2-9-6"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path4-4-9"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path6-7-3"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path8-8-7"
-         inkscape:connector-curvature="0" />
-    </g>
-    <circle
-       style="opacity:1;vector-effect:none;fill:#f6a570;fill-opacity:1;stroke:#ff6600;stroke-width:0.15314662;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path1058-8"
-       cx="84.443832"
-       cy="122.52114"
-       r="3.8784268" />
-    <g
-       id="g852-9"
-       transform="matrix(0.07659744,0,0,0.07659744,79.654676,105.76729)">
-      <path
-         d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path2-7"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path4-3"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path6-6"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path8-1"
-         inkscape:connector-curvature="0" />
-    </g>
-    <circle
-       style="opacity:1;vector-effect:none;fill:#e8ff8d;fill-opacity:1;stroke:#aad400;stroke-width:0.15340517;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path1058-3"
-       cx="68.457329"
-       cy="67.821526"
-       r="3.8837512" />
-    <g
-       id="g852-1"
-       transform="matrix(0.07670259,0,0,0.07670259,63.661592,51.044672)">
-      <path
-         d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path2-9"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path4-4"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path6-7"
-         inkscape:connector-curvature="0" />
-      <path
-         d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z"
-         style="fill:#071159;fill-rule:evenodd"
-         id="path8-8"
-         inkscape:connector-curvature="0" />
+      <ellipse
+         style="opacity:0.948;vector-effect:none;fill:none;fill-opacity:1;stroke:#071159;stroke-width:0.75;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path1563"
+         cx="91.096825"
+         cy="94.839066"
+         rx="11.397929"
+         ry="34.51218" />
+      <ellipse
+         style="opacity:0.948;vector-effect:none;fill:none;fill-opacity:1;stroke:#071159;stroke-width:0.75;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path1563-9"
+         cx="94.839066"
+         cy="-91.096825"
+         rx="11.397929"
+         ry="34.51218"
+         transform="rotate(90)" />
+      <ellipse
+         style="opacity:0.948;vector-effect:none;fill:none;fill-opacity:1;stroke:#071159;stroke-width:0.75;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path1563-5"
+         cx="131.47653"
+         cy="2.6461601"
+         rx="11.397929"
+         ry="34.51218"
+         transform="rotate(45)" />
+      <ellipse
+         style="opacity:0.948;vector-effect:none;fill:none;fill-opacity:1;stroke:#071159;stroke-width:0.75;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path1563-5-0"
+         cx="2.6461642"
+         cy="131.47653"
+         rx="11.397929"
+         ry="34.51218"
+         transform="matrix(-0.70710678,0.70710678,0.70710678,0.70710678,0,0)" />
+      <g
+         id="g17626"
+         transform="translate(0,1.5875)">
+        <circle
+           style="opacity:1;vector-effect:none;fill:#f4ddef;fill-opacity:1;stroke:#ff00cc;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path1058-32"
+           cx="69.472244"
+           cy="102.06955"
+           r="3.8784029" />
+        <g
+           id="g852-06"
+           transform="matrix(0.07659697,0,0,0.07659697,64.683117,85.315803)">
+          <path
+             d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path2-1"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path4-5"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path6-5"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path8-4"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <circle
+         style="vector-effect:none;fill:#ffe7a8;fill-opacity:1;stroke:#ffc700;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path1058-3-6"
+         cx="115.12273"
+         cy="80.660255"
+         r="3.8784029" />
+      <g
+         id="g852-1-5"
+         transform="matrix(0.07659697,0,0,0.07659697,110.33361,63.9065)">
+        <path
+           d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z"
+           style="fill:#071159;fill-rule:evenodd"
+           id="path2-9-6"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z"
+           style="fill:#071159;fill-rule:evenodd"
+           id="path4-4-9"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z"
+           style="fill:#071159;fill-rule:evenodd"
+           id="path6-7-3"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z"
+           style="fill:#071159;fill-rule:evenodd"
+           id="path8-8-7"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g852-1-5-6"
+         transform="matrix(0.18206477,0,0,0.18206477,79.910035,55.513064)">
+        <path
+           d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z"
+           style="fill:#071159;fill-rule:evenodd"
+           id="path2-9-6-2"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z"
+           style="fill:#071159;fill-rule:evenodd"
+           id="path4-4-9-3"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z"
+           style="fill:#071159;fill-rule:evenodd"
+           id="path6-7-3-1"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z"
+           style="fill:#071159;fill-rule:evenodd"
+           id="path8-8-7-2"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g17634">
+        <circle
+           style="opacity:1;vector-effect:none;fill:#fcb5bc;fill-opacity:1;stroke:#ff4955;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path1058-8"
+           cx="84.443832"
+           cy="122.52114"
+           r="3.8784268" />
+        <g
+           id="g852-9"
+           transform="matrix(0.07659744,0,0,0.07659744,79.654676,105.76729)">
+          <path
+             d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path2-7"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path4-3"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path6-6"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path8-1"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g17618"
+         transform="translate(0,1.5875)">
+        <circle
+           style="opacity:1;vector-effect:none;fill:#e8ff8d;fill-opacity:1;stroke:#aad400;stroke-width:0.4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path1058-3"
+           cx="68.457329"
+           cy="67.821526"
+           r="3.8837512" />
+        <g
+           id="g852-1"
+           transform="matrix(0.07670259,0,0,0.07670259,63.661592,51.044672)">
+          <path
+             d="m 60.4089,220.1395 -0.609,-15.6219 13.481,-8.4941 13.6126,7.2951 0.692,16.0431 -13.481,8.4935 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path2-9"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 33.6628,217.112 -0.0823,-22.4502 29.2906,-18.2808 14.0091,8.3629 c -10.1028,6.5645 -14.7455,9.3309 -24.9875,15.6991 l -0.1926,5.9751 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path4-4"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 35.0548,248.4071 -12.0432,-19.0814 28.7863,-16.8447 1.1557,12.3346 10.7928,5.589 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path6-7"
+             inkscape:connector-curvature="0" />
+          <path
+             d="m 50.128,245.2642 19.919,10.3549 29.8294,-18.2487 -1.8935,-15.6419 c -10.3375,6.1835 -14.3477,8.7856 -24.6876,14.9664 l -5.3995,-2.5663 z"
+             style="fill:#071159;fill-rule:evenodd"
+             id="path8-8"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
1. replaces the current Carpentries Lab logo with a slightly modified version that uses [our Brand Identity colours](https://docs.carpentries.org/topic_folders/communications/resources/brand_identity.html).
2. adds a simplified version of the logo that looks better when displayed in a small size, e..g. as a favicon.